### PR TITLE
Fixing q-word detection escape using Discord text styling

### DIFF
--- a/src/events/FeurResponder.ts
+++ b/src/events/FeurResponder.ts
@@ -5,7 +5,7 @@ import { Message } from 'discord.js'
 @Discord()
 export class FeurResponder {
   private static feurAsking = [ 'quoi', 'kwa' ]
-  private static feurAskingTerminator = [ '?', '!', ' ', ':', '.', ',', ';', ')', '\'', '"', '/', '\n' ]
+  private static feurAskingTerminator = [ '?', '!', ' ', ':', '.', ',', ';', ')', '\'', '"', '/', '\n', '_', '*', '~' ]
   private static feurReactionResponse = [ '🇫', '🇪', '🇺', '🇷' ]
   private static feurBotResponse = '01100110 01100101 01110101 01110010 00100000 01100110 01100100 01110000'
   private static feurLongResponseLimit = 40


### PR DESCRIPTION
This PR fixes the detection escape using Discord text styling (bold, underline, italic, strikthrough) by adding theses markers to q-word terminators (works great)