### PR TITLE
Fixing birthday dates parsing

### DIFF
--- a/src/commands/Birthdays.ts
+++ b/src/commands/Birthdays.ts
@@ -21,7 +21,6 @@ import dayjs from 'dayjs'
 @SlashGroup('birthday')
 export default class Birthdays {
   public static FORMAT = 'DD/MM/YYYY'
-  public static DATE_MATCHER = /^\d{1,2}\/\d{1,2}\/(\d{1,2}|\d{4})$/
 
   @Slash({
     name: 'get',
@@ -95,9 +94,9 @@ export default class Birthdays {
       return await interaction.reply(`You already have your birthday set to ${dayjs(birthday.date).format(Birthdays.FORMAT)}`)
     }
 
-    let dateParsed = dayjs(date, Birthdays.FORMAT, true)
+    let dateParsed = dayjs(date, Birthdays.FORMAT)
 
-    if (!date.match(Birthdays.DATE_MATCHER) || !dateParsed.isValid() || dateParsed.isAfter(dayjs())) {
+    if (!dateParsed.isValid() || dateParsed.isAfter(dayjs())) {
       return await interaction.reply(`The date ${date} is not valid. Format: ${Birthdays.FORMAT}`)
     }
 

--- a/src/commands/BirthdaysAdmin.ts
+++ b/src/commands/BirthdaysAdmin.ts
@@ -160,9 +160,9 @@ export default class BirthdaysAdmin {
       }) date: string,
       interaction: CommandInteraction,
   ) {
-    let dateParsed = dayjs(date, Birthdays.FORMAT, true)
+    let dateParsed = dayjs(date, Birthdays.FORMAT)
 
-    if (!date.match(Birthdays.DATE_MATCHER) || !dateParsed.isValid() || dateParsed.isAfter(dayjs())) {
+    if (!dateParsed.isValid() || dateParsed.isAfter(dayjs())) {
       return await interaction.reply(`The date ${date} is not valid. Format: ${Birthdays.FORMAT}`)
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,9 @@ import { IntentsBitField } from 'discord.js'
 import { Client } from 'discordx'
 import database from './utils/database.js'
 import { startNotifierJob as startBirthdayNotifierJob } from './entities/Birthday.js'
+import { configure as configureDayJS } from './utils/dayjs.js'
+
+configureDayJS()
 
 export const bot = new Client(
     {

--- a/src/utils/dayjs.ts
+++ b/src/utils/dayjs.ts
@@ -1,0 +1,6 @@
+import * as customParseFormat from 'dayjs/plugin/customParseFormat.js'
+import dayjs from 'dayjs'
+
+export function configure() {
+  dayjs.extend(customParseFormat.default)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true
   },
   "exclude": [
     "build",


### PR DESCRIPTION
This PR fixes the birthday date parsing and removes the ability of using a contracted alternative (e.g: 9/9/9 => 09/09/2009)